### PR TITLE
Fix crashes

### DIFF
--- a/src/hier/hier.c
+++ b/src/hier/hier.c
@@ -1746,6 +1746,7 @@ int Zoltan_Hier(
       ZOLTAN_FREE(&hpp.adjproc);
       ZOLTAN_FREE(&hpp.geom_vec);
       MPI_Comm_free(&hpp.hier_comm);
+      hpp.hier_comm = MPI_COMM_NULL;
     }
 
     ierr = Zoltan_LB_Free_Part(&hier_import_gids, &hier_import_lids,

--- a/src/phg/phg_build_calls.c
+++ b/src/phg/phg_build_calls.c
@@ -651,7 +651,7 @@ phg_GID_lookup       *lookup_myHshVtxs = NULL;
         ew_lids = ZOLTAN_MALLOC_LID_ARRAY(zz, myEWs.size);
         myEWs.wgt = (float *)ZOLTAN_MALLOC(myEWs.size * cnt);
 
-        if (!myEWs.edgeGID || !ew_lids || !myEWs.wgt){
+        if (!myEWs.edgeGID || !myEWs.wgt){
           MEMORY_ERROR;
         }
 


### PR DESCRIPTION
- Fixes local IDs not allocated in PHG emitting an error, since local IDs are optional and are never allocated if `num_lid_entries == 0`
- Fixes hierarchical partitioning crashing due to doubly freeing `hpp.hier_comm`. 